### PR TITLE
Escape `-` in a way that’s compatible with Unicode patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ module.exports = string => {
 
 	return string
 		.replace(matchOperatorsRegex, '\\$&')
-		.replace(/-/g, '\\x2d');
+		.replace(/-/g, '\\u002d');
 };

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const matchOperatorsRegex = /[|\\{}()[\]^$+*?.-]/g;
+const matchOperatorsRegex = /[|\\{}()[\]^$+*?.]/g;
 
 module.exports = string => {
 	if (typeof string !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
-	return string.replace(matchOperatorsRegex, '\\$&');
+	return string
+		.replace(matchOperatorsRegex, '\\$&')
+		.replace(/-/g, '\\x2d');
 };

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const matchOperatorsRegex = /[|\\{}()[\]^$+*?.]/g;
-
 module.exports = string => {
 	if (typeof string !== 'string') {
 		throw new TypeError('Expected a string');
 	}
 
+	// Escape characters with special meaning either inside or outside character sets.
+	// Use a simple backslash escape when it’s always valid, and a \unnnn escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
 	return string
-		.replace(matchOperatorsRegex, '\\$&')
+		.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
 		.replace(/-/g, '\\u002d');
 };

--- a/test.js
+++ b/test.js
@@ -11,6 +11,6 @@ test('main', t => {
 test('escapes `-`', t => {
 	t.is(
 		escapeStringRegexp('foo - bar'),
-		'foo \\x2d bar'
+		'foo \\u002d bar'
 	);
 });

--- a/test.js
+++ b/test.js
@@ -11,6 +11,6 @@ test('main', t => {
 test('escapes `-`', t => {
 	t.is(
 		escapeStringRegexp('foo - bar'),
-		'foo \\- bar'
+		'foo \\x2d bar'
 	);
 });

--- a/test.js
+++ b/test.js
@@ -14,3 +14,10 @@ test('escapes `-`', t => {
 		'foo \\u002d bar'
 	);
 });
+
+test('escapes `-` in a way compatible with the Unicode flag', t => {
+	t.regex(
+		'-',
+		new RegExp(escapeStringRegexp('-'), 'u')
+	);
+});


### PR DESCRIPTION
Regex using the `u` flag is stricter about unnecessary escapes, and disallows `\-` outside of character classes. `\x2d` means a literal hyphen both inside and outside character classes, both with and without the `u` flag.

Fixes #20.