### PR TITLE
Escape `-` in a way that’s compatible with PCRE

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,5 @@ module.exports = string => {
 	// Use a simple backslash escape when it’s always valid, and a \unnnn escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
 	return string
 		.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
-		.replace(/-/g, '\\u002d');
+		.replace(/-/g, '\\x2d');
 };

--- a/test.js
+++ b/test.js
@@ -8,10 +8,10 @@ test('main', t => {
 	);
 });
 
-test('escapes `-`', t => {
+test('escapes `-` in a way compatible with PCRE', t => {
 	t.is(
 		escapeStringRegexp('foo - bar'),
-		'foo \\u002d bar'
+		'foo \\x2d bar'
 	);
 });
 


### PR DESCRIPTION
Original form of #21, plus test description. Fixes #22.