### PR TITLE
TS compat: enable default importing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,4 +15,4 @@ new RegExp(escapedString);
 */
 declare const escapeStringRegexp: (string: string) => string;
 
-export = escapeStringRegexp;
+export default escapeStringRegexp;

--- a/index.js
+++ b/index.js
@@ -11,3 +11,5 @@ module.exports = string => {
 		.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
 		.replace(/-/g, '\\x2d');
 };
+
+module.exports.default = module.exports;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
 import {expectType} from 'tsd';
-import escapeStringRegexp = require('.');
+import escapeStringRegexp from '.';
 
 expectType<string>(escapeStringRegexp('how much $ for a 🦄?'));


### PR DESCRIPTION
This enables TypeScript developers that don't use `esModuleInterop` to consume this library when compiling for both the commonjs and es2015 module systems from the same source code.

In the current state, there are two options:

If I use
```ts
import * as escape from 'escape-string-regexp';
escape('foo');
```
it compiles fine in both cases, but throws an error like `escape is not a function` in the es2015 build at runtime. The commonjs build runs fine.

Now if I use
```ts
import escape from 'escape-string-regexp';
escape('foo');
```
instead, it throws a compile error, and if you ignore it, there's an error like `escape_string_regexp_1.default is not a function` at runtime in the commonjs build. The es2015 build runs fine.

The latter is the easier thing to fix, and it's what I fixed in this PR. In essence, I'm changing the "correct" way (for the TS compiler) from the former to the latter, and making it run in either module environment.

It's also a **breaking change** for TS users without esModuleInterop, though.