### PR TITLE
Clarify that minimal escaping is done (#30) and describe edge cases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ new RegExp(escapedString);
 
 You can also use this to escape a string that is inserted into the middle of a regex, for example, into a character class.
 
+Only the minimal amount of escaping is done, and developers are expected to insert escaped strings at safe positions in a `RegExp`. This keeps the output simple and gives you the best results in most cases. For edge case placements of escaped strings (such as immediately following `\0` or `\c`), the escaped value can change the meaning of the preceding or following token. If fully context-aware escaping is needed, consider interpolating a string using the [regex](https://github.com/slevithan/regex#interpolating-escaped-strings) library.
+
 ---
 
 <div align="center">

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ new RegExp(escapedString);
 
 You can also use this to escape a string that is inserted into the middle of a regex, for example, into a character class.
 
-Only the minimal amount of escaping is done, and developers are expected to insert escaped strings at safe positions in a `RegExp`. This keeps the output simple and gives you the best results in most cases. For edge case placements of escaped strings (such as immediately following `\0` or `\c`), the escaped value can change the meaning of the preceding or following token. If fully context-aware escaping is needed, consider interpolating a string using the [regex](https://github.com/slevithan/regex#interpolating-escaped-strings) library.
+Only the minimal amount of escaping is done, and developers are expected to insert escaped strings at safe positions in a `RegExp`. This keeps the output simple and gives you the best results in most cases. For edge case placements of escaped strings (such as immediately following `\0` or `\c`), the escaped value can change the meaning of the preceding or following token. If fully context-aware escaping is needed, consider interpolating a string using the [`regex`](https://github.com/slevithan/regex#interpolating-escaped-strings) package.
 
 ---
 


### PR DESCRIPTION
There have been multiple requests to escape additional characters, so this makes it clearer that minimal escaping is done, per https://github.com/sindresorhus/escape-string-regexp/issues/30#issuecomment-698328200. It also gives a solution for more involved context-aware escaping that handles numerous edge cases, for situations when developers need to insert an escaped string at an arbitrary position in a regex.

Fixes #30